### PR TITLE
Prepare 0.3.0 for first PyPI release

### DIFF
--- a/DEV_README.md
+++ b/DEV_README.md
@@ -84,10 +84,14 @@ You will need an API token from the respective repository. You can use `pip` to 
 
 ```
 # For testpypi
-pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ piilo
+pip install --index-url https://test.pypi.org/simple/ --extra-index-url https://pypi.org/simple/ piilo-anonymizer
 # For pypi
-pip install piilo
+pip install piilo-anonymizer
 ```
+
+The distribution is named `piilo-anonymizer` on PyPI (the shorter `piilo` was
+rejected as too similar to an existing project), but the import package and the
+`obfuscate` entry point are unchanged.
 
 ## PIILO as a Package: Overview
 

--- a/README.md
+++ b/README.md
@@ -1,13 +1,13 @@
 <div align="center">
 
-<img src="logo.png" alt="PIILO logo" width="140">
+<img src="https://raw.githubusercontent.com/langdonholmes/piilo/main/logo.png" alt="PIILO logo" width="140">
 
 # PIILO
 
 **P**ersonally **I**dentifiable **I**nformation **L**abeling and **O**bfuscation
 
 [![Tests](https://github.com/langdonholmes/piilo/actions/workflows/ci.yml/badge.svg)](https://github.com/langdonholmes/piilo/actions/workflows/ci.yml)
-[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+[![License: Apache 2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://github.com/langdonholmes/piilo/blob/main/LICENSE)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue.svg)](https://www.python.org/downloads/)
 [![Paper](https://img.shields.io/badge/paper-ILS%202023-b31b1b.svg)](https://doi.org/10.1108/ILS-04-2023-0032)
 
@@ -53,7 +53,7 @@ On macOS, XGBoost also needs the OpenMP runtime: `brew install libomp`.
 > **Note**
 > Those model files are **not** stored in the git repository, only in the
 > published package. If you install from a clone (`pip install -e .`) you must
-> fetch them separately — see [DEV_README.md](DEV_README.md).
+> fetch them separately — see [DEV_README.md](https://github.com/langdonholmes/piilo/blob/main/DEV_README.md).
 
 ## Usage
 
@@ -122,8 +122,8 @@ the same surrogate, so coreference survives deidentification.
 
 ## Development
 
-See [DEV_README.md](DEV_README.md) for the package layout, how to obtain the
-model files, and how to build a release.
+See [DEV_README.md](https://github.com/langdonholmes/piilo/blob/main/DEV_README.md)
+for the package layout, how to obtain the model files, and how to build a release.
 
 ```bash
 pip install -e ".[dev]"
@@ -152,4 +152,4 @@ If you use PIILO in your research, please cite:
 
 ## License
 
-Apache License 2.0. See [LICENSE](LICENSE).
+Apache License 2.0. See [LICENSE](https://github.com/langdonholmes/piilo/blob/main/LICENSE).

--- a/README.md
+++ b/README.md
@@ -40,21 +40,20 @@ features rather than a transformer.
 
 ## Installation
 
-PIILO is not currently published on PyPI. Install from source:
-
 ```bash
-git clone https://github.com/langdonholmes/piilo.git
-cd piilo
-pip install -e .
+pip install piilo
 ```
 
-> **Note**
-> PIILO depends on name tables and XGBoost models totalling roughly 120 MB that
-> are not stored in this repository. See [DEV_README.md](DEV_README.md) for
-> download links and where to place them. Without these files PIILO imports
-> successfully but cannot analyze text.
+The name tables and XGBoost models PIILO needs (roughly 120 MB) are bundled in
+the release, so `pip install` gives a fully working package with nothing else to
+download.
 
 On macOS, XGBoost also needs the OpenMP runtime: `brew install libomp`.
+
+> **Note**
+> Those model files are **not** stored in the git repository, only in the
+> published package. If you install from a clone (`pip install -e .`) you must
+> fetch them separately — see [DEV_README.md](DEV_README.md).
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -41,12 +41,14 @@ features rather than a transformer.
 ## Installation
 
 ```bash
-pip install piilo
+pip install piilo-anonymizer
 ```
 
-The name tables and XGBoost models PIILO needs (roughly 120 MB) are bundled in
-the release, so `pip install` gives a fully working package with nothing else to
-download.
+The package is distributed as `piilo-anonymizer` on PyPI, but you still
+`import piilo` and run the `obfuscate` command — the shorter name was already
+taken. The name tables and XGBoost models PIILO needs (roughly 120 MB) are
+bundled in the release, so `pip install` gives a fully working package with
+nothing else to download.
 
 On macOS, XGBoost also needs the OpenMP runtime: `brew install libomp`.
 

--- a/piilo/__init__.py
+++ b/piilo/__init__.py
@@ -1,3 +1,5 @@
+from importlib.metadata import PackageNotFoundError, version
+
 import spacy
 
 from .main import (
@@ -10,7 +12,13 @@ from .main import (
     get_anonymizer,
 )
 
+try:
+    __version__ = version("piilo")
+except PackageNotFoundError:  # running from a source tree that isn't installed
+    __version__ = "0.0.0"
+
 __all__ = [
+    "__version__",
     "analyze",
     "anonymize",
     "anonymize_batch",

--- a/piilo/__init__.py
+++ b/piilo/__init__.py
@@ -12,8 +12,9 @@ from .main import (
     get_anonymizer,
 )
 
+# The import package is "piilo"; the PyPI distribution is "piilo-anonymizer".
 try:
-    __version__ = version("piilo")
+    __version__ = version("piilo-anonymizer")
 except PackageNotFoundError:  # running from a source tree that isn't installed
     __version__ = "0.0.0"
 

--- a/piilo/main.py
+++ b/piilo/main.py
@@ -149,7 +149,10 @@ def anonymize_batch(dir: str, entities=None, language="en", file_format="csv") -
 
 
 def anonymize_batch_cli():
+    from piilo import __version__
+
     parser = argparse.ArgumentParser(description="Anonymize text files in a directory.")
+    parser.add_argument("--version", action="version", version=f"piilo {__version__}")
     parser.add_argument(
         "--dir",
         type=str,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = ["setuptools>=68"]
 build-backend = "setuptools.build_meta"
 
 [project]
-name = "piilo"
+name = "piilo-anonymizer"
 version = "0.3.0"
 description = "Personally Identifiable Information Labeling and Obfuscation for student text"
 readme = "README.md"


### PR DESCRIPTION
Pre-release polish; 0.3.0 is now published to PyPI as **piilo-anonymizer**: https://pypi.org/project/piilo-anonymizer/0.3.0/

## Changes
- **Distribution renamed to `piilo-anonymizer`.** PyPI rejected `piilo` as too similar to the existing `pilo` project. The import package (`import piilo`) and the `obfuscate` CLI are unchanged — only the `pip install` name differs.
- Expose `piilo.__version__` (read from installed metadata under the distribution name) and add `obfuscate --version`.
- README/DEV_README: document `pip install piilo-anonymizer`, note the package bundles its ~120 MB of model files so install is fully functional, and use absolute URLs so the logo and doc links render on the PyPI project page.

## Validation
- Built wheel (66.5 MB, under PyPI's 100 MB limit) installs into a clean venv, `import piilo` works, `__version__` reports 0.3.0, and anonymization runs with no leak.
- `twine check --strict` passes; pytest green.